### PR TITLE
Update backend parameters

### DIFF
--- a/src/small_thoughts/utils/reason.py
+++ b/src/small_thoughts/utils/reason.py
@@ -34,7 +34,7 @@ def reason(dataset, base_url, model_name, temperture=0.0, max_tokens=8192, syste
     reasoner = Reasoner(
         model_name=model_name,
         generation_params={"temp": temperture, "max_tokens": max_tokens},
-        backend_params={"base_url": base_url, "max_requests_per_minute": max_requests_per_minute, "max_tokens_per_minute": max_tokens_per_minute},
+        backend_params={"base_url": base_url, "max_requests_per_minute": max_requests_per_minute, "max_tokens_per_minute": max_tokens_per_minute, "max_retries": 1, "require_all_responses": False},
         system_prompt=REASONING_PROMPT[system_prompt_type],
     )
     return reasoner(dataset)

--- a/src/small_thoughts/utils/translate.py
+++ b/src/small_thoughts/utils/translate.py
@@ -30,7 +30,7 @@ def translate(dataset, base_url, model_name, temperture=0.0, max_tokens=8192, sy
     reasoner = Translater(
         model_name=model_name,
         generation_params={"temp": temperture, "max_tokens": max_tokens},
-        backend_params={"base_url": base_url, "max_requests_per_minute": max_requests_per_minute, "max_tokens_per_minute": max_tokens_per_minute},
+        backend_params={"base_url": base_url, "max_requests_per_minute": max_requests_per_minute, "max_tokens_per_minute": max_tokens_per_minute, "max_retries": 1, "require_all_responses": False},
         system_prompt=TRANSLATION_PROMPT[system_prompt_type],
     )
     return reasoner(dataset)


### PR DESCRIPTION
This pull request introduces updates to the `backend_params` configuration in both the `reason` and `translate` utility functions to enhance their robustness and flexibility. Specifically, it adds new parameters for handling retries and response requirements.

### Updates to `backend_params`:

* [`src/small_thoughts/utils/reason.py`](diffhunk://#diff-2e06a98603f36be4c2f37c601bf3baed77c5467b60ac00a9e14bc648be2db815L37-R37): The `reason` function's `backend_params` now includes `max_retries` (set to 1) and `require_all_responses` (set to `False`), improving error handling and allowing partial responses.
* [`src/small_thoughts/utils/translate.py`](diffhunk://#diff-251f3b058bf4689ab370901b2b5d190f5e264a9d4150a9cf93d20cfdce7790f9L33-R33): The `translate` function's `backend_params` has been updated with the same additions (`max_retries` and `require_all_responses`) to align its behavior with the `reason` function.